### PR TITLE
Adaptive terminal size

### DIFF
--- a/include/model/greasemonkey.h
+++ b/include/model/greasemonkey.h
@@ -42,6 +42,6 @@ namespace CliAniHury {
         void initScene(int scene, int effect, int seed);
     };
 
-}; // end of namespace CliAniHury
+} // end of namespace CliAniHury
 
 #endif //CLIANIMATION_GREASEMONKEY_H

--- a/include/model/noisedef.h
+++ b/include/model/noisedef.h
@@ -133,5 +133,5 @@ namespace tasty {
         }
     };
 
-}; // end of namespace tasty
+} // end of namespace tasty
 #endif //CLIANIMATION_NOISEDEF_H

--- a/include/view/cliview.h
+++ b/include/view/cliview.h
@@ -30,6 +30,7 @@ namespace CliAniHury {
         void printAt(int x, int y, const char *printStr);
         void requestCharacters(char *input, int n);
         int requestUserSeed(char *input, int n);
+        void updateTermSize(int ncols, int nrows);
 
         /**
          * @deprecated UNUSED FUNCTION!

--- a/include/widdershins.h
+++ b/include/widdershins.h
@@ -27,12 +27,14 @@ namespace CliAniHury {
 
         void start();
         void runFrame(int time);
+        void scheduleResize();
 
 
     private:
         CliView* _View;
         GreaseMonkey _Engine;
         opmode_run_func _RunFunc = nullptr;
+        bool resizeTriggered = false;
 
     };
 }; // end of namespace CliAniHury

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,9 +12,13 @@
 #include <utilz/hutime.h>
 
 std::atomic<bool> quit(false);
+CliAniHury::Widdershins ctrl;
 
 void got_signal(int signum) {
-    quit.store(true);
+    if (signum == SIGWINCH)
+        ctrl.scheduleResize();
+    else if (signum == SIGINT)
+        quit.store(true);
 }
 
 
@@ -27,12 +31,14 @@ void got_signal(int signum) {
         sigInt.sa_flags = 0;
 
         sigaction(SIGINT, &sigInt, NULL);
+        sigaction(SIGWINCH, &sigInt, NULL);
 
-        CliAniHury::Widdershins ctrl;
         CliAniHury::CliView hr_view;
 
         // Registers View-module at ctrl for ncurses usage
         ctrl.registerCliView(&hr_view);
+        // Update the window size once in the beginning to fit the terminal
+        ctrl.scheduleResize();
         // Starts program with requesting user input and preparing modules
         ctrl.start();
 

--- a/src/view/cliview.cpp
+++ b/src/view/cliview.cpp
@@ -105,6 +105,10 @@ namespace CliAniHury {
         refresh();
     }
 
+    void CliView::updateTermSize(int ncols, int nrows) {
+        resizeterm(nrows, ncols);
+    }
+
     void CliView::printAt(int x, int y, const char *printStr) {
         // Adds new line on top
         move(0,0);

--- a/src/view/cliview.cpp
+++ b/src/view/cliview.cpp
@@ -97,7 +97,7 @@ namespace CliAniHury {
 
     void CliView::removeBottomLine() {
         // Deletes the bottom line
-        move(WINDOW_LINE_HEIGHT,0);
+        move(LINES-1,0);
         deleteln();
         // moves curser to 0,0
         move(0,0);

--- a/src/widdershins.cpp
+++ b/src/widdershins.cpp
@@ -6,6 +6,7 @@
 
 #include <widdershins.h>
 #include <cstdio>
+#include <sys/ioctl.h>
 
 namespace CliAniHury {
 
@@ -46,7 +47,18 @@ namespace CliAniHury {
         _Engine.setup(opmode, _View->getSeed(), _View->getSelection());
     }
 
+    void performResize(CliView* view) {
+
+        struct winsize size;
+        if(ioctl(0, TIOCGWINSZ, (char *) &size) < 0)
+            ; // TODO: Handle error message or such
+        view->updateTermSize(size.ws_col, size.ws_row);
+    }
+
     void Widdershins::runFrame(int time) {
+
+        if (resizeTriggered)
+            performResize(_View);
 
         (*_RunFunc)(*_View, _Engine);
 
@@ -67,4 +79,8 @@ namespace CliAniHury {
         view.waiting(50);
     }
 
-}; // end of namespace CliAniHury
+    void Widdershins::scheduleResize() {
+        resizeTriggered = true;
+    }
+
+} // end of namespace CliAniHury


### PR DESCRIPTION
Currently terminal dimensions are hardcoded. Add support for resizable terminals.
This should also fix a current bug where scrolling does not work if the row count of the terminal is smaller than the hardcoded height.